### PR TITLE
Remove obsolete checkout step

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
       - name: Validate
         uses: harmenjanssen/commit-message-validation-action@master
         env:


### PR DESCRIPTION
The validating step doesn't need the checkout. It uses the Github API to fetch the latest commit.